### PR TITLE
added scope to oauth request

### DIFF
--- a/lib/passport-soundcloud/strategy.js
+++ b/lib/passport-soundcloud/strategy.js
@@ -43,6 +43,8 @@ function Strategy(options, verify) {
   options = options || {};
   options.authorizationURL = options.authorizationURL || 'https://soundcloud.com/connect';
   options.tokenURL = options.tokenURL || 'https://api.soundcloud.com/oauth2/token';
+  options.scopeSeparator = options.scopeSeparator || ',';
+
   
   OAuth2Strategy.call(this, options, verify);
   this.name = 'soundcloud';


### PR DESCRIPTION
soundcloud now requires a "non-expiring" scope in order to access indefinitely, re: http://developers.soundcloud.com/docs/api/reference#connect 
